### PR TITLE
Improve wfb_bridge wifi removal detection

### DIFF
--- a/conf/wfb_bridge
+++ b/conf/wfb_bridge
@@ -53,7 +53,7 @@
 # 31        260   64-QAM
 
 [global]
-mode = air
+mode = ground
 loglevel = critical
 sysloglevel = info
 sysloghost = localhost

--- a/conf/wfb_bridge
+++ b/conf/wfb_bridge
@@ -53,7 +53,7 @@
 # 31        260   64-QAM
 
 [global]
-mode = ground
+mode = air
 loglevel = critical
 sysloglevel = info
 sysloghost = localhost

--- a/include/raw_socket.hh
+++ b/include/raw_socket.hh
@@ -63,6 +63,7 @@ private:
 
 class RawReceiveSocket {
 public:
+  
   RawReceiveSocket(bool ground, uint32_t max_packet = 65535);
 
   bool add_device(const std::string &device);

--- a/src/raw_socket.cc
+++ b/src/raw_socket.cc
@@ -422,7 +422,9 @@ bool RawReceiveSocket::receive(monitor_message_t &msg, std::chrono::duration<dou
   while((retval = pcap_next_ex(m_ppcap, &pcap_packet_header, &pcap_packet_data)) == 0) {
     auto cur = std::chrono::high_resolution_clock::now();
     if ((cur - start) > timeout) {
-      return false;
+      // An empty message with a return of true implies timeout
+      msg.data.clear();
+      return true;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }


### PR DESCRIPTION
Checks the return status from pcap_next_ex to try to detect when a wifi card has been removed. This appears to be working well, and this should resolve issue #1.